### PR TITLE
Add log

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -204,7 +204,7 @@ implemented, should be the next ones to be implemented, as soon as feasible.
 Along with these two features, the addition of two commands is intended for
 version 0.02:
 
- - [ ] `log` will, starting at the HEAD, display all commits back to the initial
+ - [x] `log` will, starting at the HEAD, display all commits back to the initial
 commit
 
  - [ ] `checkout` will, given a complete hash, or 'HEAD', overwrite the contents

--- a/VersionControl/VersionControl.cpp
+++ b/VersionControl/VersionControl.cpp
@@ -443,7 +443,8 @@ void log() {
 		std::cout << "\t" << line.substr(6) << "\n\n"; // 6 characters: "title "
 
 		// And finally the message
-		std::getline(commit, line);
+		std::getline(commit, line, '&'); // Discard the beginning
+		std::getline(commit, line, '&'); // And fetch the entire message
 		std::cout << "\t" << line.substr(8) << "\n\n"; // 8 characters: "message "
 
 		commit.close();

--- a/VersionControl/VersionControl.cpp
+++ b/VersionControl/VersionControl.cpp
@@ -15,6 +15,7 @@
 #include <sstream>
 #include <chrono>
 #include <vector>
+#include <iomanip>
 
 // Internal codes for commands which we know how to handle, plus an error code (unknownCommand)
 enum class Command : uint8_t { unknownCommand, init, add, commit, commitLast, commitFiles, log};
@@ -452,7 +453,8 @@ void log() {
 		std::getline(commit, line, '&'); // And fetch the entire message
 		line = escaped(line, "/amp;", "&");
 		line = escaped(line, "/sl;", "/");
-		std::cout << "\t" << line << "\n\n"; // 8 characters: "message "
+		line = escaped(line, "\n", "\n\t"); // Indent every line of the commit message
+		std::cout << "\t" << line << "\n\n";
 
 		commit.close();
 	}

--- a/VersionControl/VersionControl.cpp
+++ b/VersionControl/VersionControl.cpp
@@ -442,12 +442,16 @@ void log() {
 
 		// The title
 		std::getline(commit, line);
-		std::cout << "\t" << line.substr(6) << "\n\n"; // 6 characters: "title "
+		line = escaped(line.substr(6), "/amp;", "&");
+		line = escaped(line, "/sl;", "/");
+		std::cout << "\t" << line << "\n\n"; // 6 characters: "title "
 
 		// And finally the message
 		std::getline(commit, line, '&'); // Discard the beginning
 		std::getline(commit, line, '&'); // And fetch the entire message
-		std::cout << "\t" << line.substr(8) << "\n\n"; // 8 characters: "message "
+		line = escaped(line, "/amp;", "&");
+		line = escaped(line, "/sl;", "/");
+		std::cout << "\t" << line << "\n\n"; // 8 characters: "message "
 
 		commit.close();
 	}

--- a/VersionControl/VersionControl.cpp
+++ b/VersionControl/VersionControl.cpp
@@ -278,12 +278,14 @@ void commit() {
 	// Get commit title from the user and write, escaped, to commit
 	std::cout << "Commit title: ";
 	std::getline(std::cin, title);
-	commit << "title " << escaped(title, "&", "&amp;") << "\n";
+	title = escaped(title, "/", "/sl;");
+	commit << "title " << escaped(title, "&", "/amp;") << "\n";
 
 	// Do the same for the commit message
 	std::cout << "Commit message (type Ctrl-X then press enter to end):\n";
 	std::getline(std::cin, title, char(24));
-	commit << "message &" << escaped(title, "&", "&amp;") << "&\n";
+	title = escaped(title, "/", "/sl;");
+	commit << "message &" << escaped(title, "&", "/amp;") << "&\n";
 
 	// Now, get the list of files in the index, and add their names to the commit header.
 	std::vector<std::string> files;

--- a/VersionControl/VersionControl.cpp
+++ b/VersionControl/VersionControl.cpp
@@ -189,7 +189,7 @@ void init() {
 
 	// Finish off the header
 	commit << "title Initial Commit\n";
-	commit << "message This commit marks the initialization of the repository.\n";
+	commit << "message &This commit marks the initialization of the repository.&\n";
 	commit << "files []\n";
 	commit << "&&&&&\n";
 

--- a/VersionControl/VersionControl.cpp
+++ b/VersionControl/VersionControl.cpp
@@ -137,6 +137,11 @@ int main(int argc, char* argv[]) {
 			commitLast();
 			break;
 		}
+		case Command::log:
+		{
+			log();
+			break;
+		}
 		default:
 		{
 			std::cerr << "Unrecognized commandline:";

--- a/VersionControl/VersionControl.cpp
+++ b/VersionControl/VersionControl.cpp
@@ -83,13 +83,20 @@ int main(int argc, char* argv[]) {
 	else if (!strcmp(argv[1], "commit")) {
 		mode = Command::commit;
 
-		if (argc>2) {
+		if (argc > 2) {
 			if (!strcmp(argv[2], "-h")) {
 				usage(argv[0], Command::commit);
 			}
 			else if (!strcmp(argv[2], "-a")) {
 				mode = Command::commitLast;
 			}
+		}
+	}
+	else if (!strcmp(argv[1], "log")) {
+		mode = Command::log;
+
+		if (argc > 2) {
+			usage(argv[0], Command::log);
 		}
 	}
 	else if (!strcmp(argv[1], "init")) {

--- a/VersionControl/VersionControl.cpp
+++ b/VersionControl/VersionControl.cpp
@@ -445,5 +445,7 @@ void log() {
 		// And finally the message
 		std::getline(commit, line);
 		std::cout << "\t" << line.substr(8) << "\n\n"; // 8 characters: "message "
+
+		commit.close();
 	}
 }

--- a/VersionControl/VersionControl.cpp
+++ b/VersionControl/VersionControl.cpp
@@ -56,6 +56,7 @@ void usage(char* invoke, Command source) {
 		std::cout << invoke << " init\n";
 		std::cout << invoke << " add [files]\n";
 		std::cout << invoke << " commit [files] [-a]\n";
+		std::cout << invoke << " log\n";
 		break;
 	}
 	exit(0);

--- a/VersionControl/VersionControl.cpp
+++ b/VersionControl/VersionControl.cpp
@@ -284,6 +284,7 @@ void commit() {
 	// Do the same for the commit message
 	std::cout << "Commit message (type Ctrl-X then press enter to end):\n";
 	std::getline(std::cin, title, char(24));
+	title = escaped(title, std::string((char)24,1), ""); // Just in case
 	title = escaped(title, "/", "/sl;");
 	commit << "message &" << escaped(title, "&", "/amp;") << "&\n";
 

--- a/VersionControl/VersionControl.cpp
+++ b/VersionControl/VersionControl.cpp
@@ -51,6 +51,11 @@ void usage(char* invoke, Command source) {
 		std::cout << "These files will be treated as those which shall be the ONLY ones committed.\n";
 		std::cout << "Note that if the index is altered while this command is running, the commit may be produced in an inconsistent state.\n";
 		break;
+	case Command::log:
+		std::cout << invoke << " log\n";
+		std::cout << "Outputs a version history of the repository by commits.\n";
+		std::cout << "No arguments are required or allowed.\n";
+		break;
 	case Command::unknownCommand:
 	default:
 		std::cout << invoke << " init\n";


### PR DESCRIPTION
(if applicable) Fixes #8  .

Merging this pull request includes the changes:

 - Enable the `log` command
 
 - Add instructions for using `log` to the usage messages
 
 - Changes to `init` and `commit` to let `log` do its job
 
The following people should be notified about this pull request:
 
 - @za419
 
If this pull request manages to destroy everything, including but not limited to:

 - The program
 
 - The repository
 
 - GitHub
 
 - Git
 
 - The concept of version control
 
 - Life as we know it
 
 - Life on Earth in general
 
 - Life, the Universe, and Everything
 
I acknowledge that I shall be ridiculed, possibly publicly (for whichever definition 
of the public survives the ensuing catastrophe).
