### PR TITLE
Add checkout lock

### DIFF
--- a/VersionControl/VersionControl.cpp
+++ b/VersionControl/VersionControl.cpp
@@ -417,15 +417,23 @@ void commit() {
 	file.write(contents.c_str(), contents.size());
 	file.close();
 
-	// And update the HEAD marker to match this commit
-	std::ofstream head(".vcs/HEAD", std::ios::trunc);
-	if (!head) {
-		remove((".vcs/commits/" + hash).c_str());
-		std::cerr << "Could not create commit.\n";
-		exit(2);
+	// If we're in a detached state, warn about not updating HEAD and print our hash
+	if (detached) {
+		std::cerr << "Warning: HEAD marker not updated: You are in a detached state.\n";
+		std::cerr << "This commit can be accessed in the future via its hash:\n";
+		std::cerr << hash << "\n";
 	}
-	head << hash << "\n";
-	head.close();
+	// Else, update the HEAD marker to match this commit
+	else {
+		std::ofstream head(".vcs/HEAD", std::ios::trunc);
+		if (!head) {
+			remove((".vcs/commits/" + hash).c_str());
+			std::cerr << "Could not create commit.\n";
+			exit(2);
+		}
+		head << hash << "\n";
+		head.close();
+	}
 
 	emptyDirectory(".vcs/index");
 

--- a/VersionControl/VersionControl.cpp
+++ b/VersionControl/VersionControl.cpp
@@ -545,8 +545,23 @@ void log() {
 //  - A complete hash
 //  - HEAD (which shall be resolved to the complete hash of the current head commit)
 void checkout(std::string reference) {
+	auto head = getHeadHash(); // For the lockout warning
+
 	if (reference == "HEAD") {
-		reference = getHeadHash();
+		reference = head;
+		remove(".vcs/COMMIT_LOCK"); // Delete the lock file
+	}
+	else if (reference != head) {
+		// Create the lock file
+		std::ofstream lock(".vcs/COMMIT_LOCK", std::ios::binary);
+		lock << reference << "\n";
+
+		// And issue a warning
+		std::cerr << "Warning: You are detached from the HEAD commit.\n";
+		std::cerr << "Commits made in this state will be lost forever unless you remember their hash.\n\n";
+	}
+	else {
+		remove(".vcs/COMMIT_LOCK"); // Delete the lock file
 	}
 
 	std::ifstream commit(".vcs/commits/"+reference, std::ios::binary);

--- a/VersionControl/VersionControl.cpp
+++ b/VersionControl/VersionControl.cpp
@@ -286,6 +286,26 @@ void add(const std::vector<std::string>& files) {
 // Copy the files in the index into a commit file in the commits folder
 // This file will have its SHA256 as its filename, and will have formatting compatible with the format specified in commit-blob.txt
 void commit() {
+	bool detached(false);
+
+	// Check for the commit lock
+	if (std::ifstream lock = std::ifstream(".vcs/COMMIT_LOCK", std::ios::binary)) {
+		// Committing is locked: We should issue a warning 
+		detached = true;
+
+		std::string hash;
+		std::getline(lock, hash);
+
+		std::cerr << "Warning: You are in detached head state.\n";
+		std::cerr << "The head commit is " << getHeadHash() << ".\n";
+		std::cerr << "The currently checked out commit is recorded as " << hash << ".\n";
+		std::cerr << "Committing in this state will not update the HEAD marker, and consequently\n";
+		std::cerr << "  any commit you might make here will not appear in logs and will only be\n";
+		std::cerr << "  reachable if you know their hash.\n";
+		std::cerr << "To avoid this, copy your work to another location, press Ctrl-C to stop commit,\n";
+		std::cerr << "  and run `checkout HEAD`. You can then copy your work back and commit.\n";
+	}
+
 	std::string title; // Commit title
 	std::string message; // Commit message
 	std::stringstream commit; // Stores the growing commit in memory. Technically, we shouldn't do this, but... you know.


### PR DESCRIPTION
(if applicable) Fixes #24.

Merging this pull request includes the changes:
 
 - Track whether or not the checked-out commit is the HEAD
 
 - If it isn't, warn about making commits on `checkout`
 
 - Also if it isn't, warn before making a commit

 - And after making a commit, tell the user that the commit cannot be accessed without its hash, and print said hash
 
The following people should be notified about this pull request:
 
 - @za419
 
If this pull request manages to destroy everything, including but not limited to:

 - The program
 
 - The repository
 
 - GitHub
 
 - Git
 
 - The concept of version control
 
 - Life as we know it
 
 - Life on Earth in general
 
 - Life, the Universe, and Everything
 
I acknowledge that I shall be ridiculed, possibly publicly (for whichever definition 
of the public survives the ensuing catastrophe).
